### PR TITLE
use rubygems status api instead of parsing html response

### DIFF
--- a/app/models/external_dependency.rb
+++ b/app/models/external_dependency.rb
@@ -25,22 +25,8 @@ class ExternalDependency
       output = {}
 
       begin
-        doc = Nokogiri::HTML(UrlRetriever.new('http://status.rubygems.org/').retrieve_content)
-        page_status = doc.at_css("div[class~='page-status']") 
-        if page_status.nil?
-          stripped = 'invalid'
-        else
-          stripped = page_status['class'].sub!("page-status", "").sub!("status-","").strip!
-        end
-        @valid = "none;minor;major;critical"
-        if(@valid.include?(stripped))
-          output[:status] = stripped
-        else
-          output[:status] = 'page broken'
-        end
-
-      rescue Nokogiri::SyntaxError => e
-        output[:status] = 'page broken'
+        response_body = UrlRetriever.new('https://pclby00q90vc.statuspage.io/api/v2/status.json').retrieve_content
+        output[:status] = extract_rubygems_status(response_body)
       rescue StandardError => e
         output[:status] = 'unreachable'
       end
@@ -61,6 +47,10 @@ class ExternalDependency
 
     def refresh_status(name)
       send("#{name}_status")
+    end
+
+    def extract_rubygems_status(response_body)
+      JSON.parse(response_body).fetch('status', {}).fetch('indicator', 'unreachable')
     end
   end
 end

--- a/spec/models/external_dependency_spec.rb
+++ b/spec/models/external_dependency_spec.rb
@@ -42,33 +42,33 @@ describe ExternalDependency, :type => :model do
 
   context 'rubygems status' do
     it 'initialized an none status' do
-      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {'<div class="page-status status-none">All Systems Operational</div>' }
+      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {"{\"status\":{\"indicator\":\"none\",\"description\":\"All Systems Operational\"}}" }
 
       expect(ExternalDependency.rubygems_status).to eq("{\"status\":\"none\"}")
     end
 
     it 'initialized a minor status' do
-      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {'<div class="page-status status-minor">Minor or something</div>' }
+      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {"{\"status\":{\"indicator\":\"minor\",\"description\":\"Some minor issues\"}}" }
 
       expect(ExternalDependency.rubygems_status).to eq("{\"status\":\"minor\"}")
     end
 
     it 'initialized a major status' do
-      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {'<div class="page-status status-major">Major or something</div>' }
+      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {"{\"status\":{\"indicator\":\"major\",\"description\":\"Some major issues\"}}" }
 
       expect(ExternalDependency.rubygems_status).to eq("{\"status\":\"major\"}")
     end
 
     it 'initialized a critical status' do
-      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {'<div class="page-status status-critical">Critial or something</div>' }
+      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {"{\"status\":{\"indicator\":\"critical\",\"description\":\"Some critical issues\"}}" }
 
       expect(ExternalDependency.rubygems_status).to eq("{\"status\":\"critical\"}")
     end
 
-    it 'initialized a page broken status' do
-      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) {'<div>Cannot find anything here</div>' }
+    it 'initialized an unreachable status when it recieved an unparsable response' do
+      allow_any_instance_of(UrlRetriever).to receive(:retrieve_content) { "{\"foo\":\"bar\"}" }
 
-      expect(ExternalDependency.rubygems_status).to eq("{\"status\":\"page broken\"}")
+      expect(ExternalDependency.rubygems_status).to eq("{\"status\":\"unreachable\"}")
     end
 
     it 'initialized an unreachable status when it recieved no response' do


### PR DESCRIPTION
As discussed in https://github.com/pivotal/projectmonitor/pull/97 - feel free to adopt and update your on PR as referenced. 
